### PR TITLE
Fix 'Ver Orçamento' button popup

### DIFF
--- a/script.js
+++ b/script.js
@@ -1848,9 +1848,14 @@ th, td { padding: 4px 6px; }
         }
         
         async function openQuoteInNewWindow(quoteData) {
+            const quoteWindow = window.open('', '_blank');
+            if (!quoteWindow) {
+                alert("Pop-up bloqueado. Por favor, permita pop-ups para este site.");
+                return;
+            }
+
             const quoteHtml = await buildQuoteHtml(quoteData);
 
-            const quoteWindow = window.open('', '_blank');
             if (quoteWindow) {
                 quoteWindow.document.write('<html><head><title>Visualizar Orçamento</title></head><body></body></html>');
                 quoteWindow.document.close();


### PR DESCRIPTION
## Summary
- open the new quote window before building HTML to avoid popup blockers

## Testing
- `pip install -r requirements.txt` *(fails: Tunnel connection failed)*

------
https://chatgpt.com/codex/tasks/task_e_684962ca2f1c832888c00677524fdb89